### PR TITLE
Default insertTextFormat to null

### DIFF
--- a/src/protocol.vala
+++ b/src/protocol.vala
@@ -462,7 +462,7 @@ namespace LanguageServer {
         public bool deprecated { get; set; }
         public Gee.List<CompletionItemTag> tags { get; private set; default = new Gee.ArrayList<CompletionItemTag> (); }
         public string? insertText { get; set; }
-        public InsertTextFormat insertTextFormat { get; set; }
+        public InsertTextFormat? insertTextFormat { get; set; default = null; }
         private uint _hash;
 
         private CompletionItem () {}


### PR DESCRIPTION
I was trying to use the Vala language server with `LanguageClient-neovim`, and completion wasn't working at all. Upon investigation, it looks like the language server was sending a value of 0 for `insertTextFormat`, which the client considered invalid.

I have no idea _why_ it was being set to 0 since the enum appears to define plain text as its default via the `CCode` attribute, but that didn't seem to be working at all for me. Using the `default` initializer works, though.

One fix would be to use the initializer to set it to plain text, but the [specification](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion) lists every CompletionItem field as optional except for `label`, so I think the better fix is to just default it to not being included unless set explicitly.

Tested with tag 0.48 built from source.