### PR TITLE
Fix build with `makepkg` on MSYS2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -64,6 +64,7 @@ endif
 
 subdir('data')
 subdir('src')
+
 if get_option('plugins')
   subdir('plugins/gnome-builder')
 endif

--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,11 @@ else
 endif
 
 subdir('data')
-subdir('plugins/gnome-builder')
 subdir('src')
-subdir('test')
+if get_option('plugins')
+  subdir('plugins/gnome-builder')
+endif
+
+if get_option('tests')
+  subdir('test')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,5 @@ option('active_parameter', type: 'boolean', value: false, description: 'Support 
 option('debug_mem', type: 'boolean', value: false, description: 'Debug memory usage')
 option('builder_abi', type: 'string', value: 'auto', description: 'Builder ABI version. Use a value like \'3.38\'')
 option('man_pages', type: 'feature', value: 'auto', description: 'Generate and install man pages.')
+option('plugins', type: 'boolean', value: 'true', description: 'Build plugin for Gnome-builder.')
+option('tests', type: 'boolean', value: 'true', description: 'Build tests.')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,5 +2,5 @@ option('active_parameter', type: 'boolean', value: false, description: 'Support 
 option('debug_mem', type: 'boolean', value: false, description: 'Debug memory usage')
 option('builder_abi', type: 'string', value: 'auto', description: 'Builder ABI version. Use a value like \'3.38\'')
 option('man_pages', type: 'feature', value: 'auto', description: 'Generate and install man pages.')
-option('plugins', type: 'boolean', value: 'true', description: 'Build plugin for Gnome-builder.')
+option('plugins', type: 'boolean', value: 'true', description: 'Install plugins.')
 option('tests', type: 'boolean', value: 'true', description: 'Build tests.')

--- a/plugins/gnome-builder/meson.build
+++ b/plugins/gnome-builder/meson.build
@@ -6,8 +6,7 @@ if builder_abi == 'auto'
   # attempt to guess the correct ABI from the installed GNOME Builder
   sh = find_program('sh', native: true, required: false)
   sed = find_program('sed', native: true, required: false)
-  gnome_builder = find_program('gnome-builder',
-    dirs: [get_option('prefix') / get_option('libdir')], native: true, required: false)
+  gnome_builder = find_program('gnome-builder', native: true, required: false)
   if gnome_builder.found() and sed.found() and sh.found()
     r = run_command(sh, '-c', gnome_builder.full_path() + ' --version | ' + sed.full_path() + ' -nr \'/GNOME Builder/ { s/GNOME Builder ([[:digit:]]+\.[[:digit:]]+).*$/\\1/ p }\'', check: true)
     builder_abi = r.stdout().strip()


### PR DESCRIPTION
```text
==> Starting build()...
The Meson build system
Version: 0.58.0
Source dir: D:/Codelabs/GitHub/msys/src/vala-language-server-0.48.2
Build dir: D:/Codelabs/GitHub/msys/src/build-x86_64-w64-mingw32
Build type: native build
Project name: vala-language-server
Project version: 0.48.2
C compiler for the host machine: gcc (gcc 10.3.0 "gcc (Rev2, Built by MSYS2 project) 10.3.0")
C linker for the host machine: gcc ld.bfd 2.36.1
Vala compiler for the host machine: valac (valac 0.52.2)
Host machine cpu family: x86_64
Host machine cpu: x86_64
Found pkg-config: C:\msys\mingw64\bin/pkg-config.EXE (1.7.4)
Run-time dependency libvala-0.52 found: YES 0.52.2
Run-time dependency gobject-2.0 found: YES 2.68.2
Run-time dependency jsonrpc-glib-1.0 found: YES 3.38.0
Run-time dependency glib-2.0 found: YES 2.68.2
Run-time dependency gio-2.0 found: YES 2.68.2
Run-time dependency gee-0.8 found: YES 0.20.3
Run-time dependency json-glib-1.0 found: YES 1.6.2
Library posix found: YES
Configuring config.vala using configuration
Run-time dependency gio-windows-2.0 found: YES 2.68.2
Found pkg-config: C:\msys\mingw64\bin/pkg-config.EXE (1.7.4)
Found CMake: C:\msys\mingw64\bin/cmake.EXE (3.20.3)
Build-time dependency scdoc found: NO (tried pkgconfig and cmake)
Program sh found: YES (C:\msys\usr\bin/sh.EXE)
Program sed found: YES (C:\msys\usr\bin/sed.EXE)

../vala-language-server-0.48.2/plugins/gnome-builder/meson.build:9:2: ERROR: Search directory /mingw64/lib is not an absolute path.

A full log can be found at D:/Codelabs/GitHub/msys/src/build-x86_64-w64-mingw32/meson-logs/meson-log.txt
==> ERROR: A failure occurred in build().
```