### PR TITLE
Fix build from source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ guix environment vala-language-server
 
 ## Building from Source
 ```sh
-meson -Dprefix=/usr/bin build
+meson -Dprefix=/usr build
 ninja -C build
 sudo ninja -C build install
 ```


### PR DESCRIPTION
This fixes #218 

Now, it should install VLS on the right folder 😉 