### PR TITLE
check for Ide.LspSearchProvider in plugin (#221)

### DIFF
--- a/plugins/gnome-builder/vala_langserv.py
+++ b/plugins/gnome-builder/vala_langserv.py
@@ -199,6 +199,7 @@ class VlsHoverProvider(Ide.LspHoverProvider):
         self.props.priority = 100
         VlsService.bind_client(self)
 
-class VlsSearchProvider(Ide.LspSearchProvider):
-    def do_load(self, context):
-        VlsService.bind_client_lazy(self)
+if hasattr(Ide, 'LspSearchProvider'):       # for earlier versions of Builder
+    class VlsSearchProvider(Ide.LspSearchProvider):
+        def do_load(self, context):
+            VlsService.bind_client_lazy(self)


### PR DESCRIPTION
If the out-of-tree plugin is installed on earlier versions of GNOME Builder (3.38 and below), then Ide.LspSearchProvider is not present.

Closes #221 