### PR TITLE
Add support for struct aliases completition

### DIFF
--- a/src/codehelp/completionengine.vala
+++ b/src/codehelp/completionengine.vala
@@ -1053,6 +1053,12 @@ namespace Vls.CompletionEngine {
                     completions.add (new CompletionItem.from_symbol (type, constant_sym, current_scope, CompletionItemKind.Constant, lang_serv.get_symbol_documentation (project, constant_sym)));
                 }
             }
+
+            // get instance members of base_struct
+            if (struct_sym.base_type != null) {
+                add_completions_for_type (lang_serv, project, code_style, type, struct_sym.base_struct,
+                        completions, current_scope, in_oce, false, seen_props, seen_type_symbols);
+            }
         } else if (type_symbol is Vala.TypeParameter) {
             var typeparam_sym = (Vala.TypeParameter) type_symbol;
             var generic_type = new Vala.GenericType (typeparam_sym);

--- a/src/codehelp/completionengine.vala
+++ b/src/codehelp/completionengine.vala
@@ -1033,6 +1033,11 @@ namespace Vls.CompletionEngine {
                         in_oce,
                         is_cm_this_or_base_access))
                     continue;
+                // Avoid base struct creation and static methods
+                if (((method_sym is Vala.CreationMethod) || method_sym.binding == Vala.MemberBinding.STATIC)) {
+                    if (current_scope.owner.name != null && current_scope.owner.name != struct_sym.scope.owner.name)
+                        continue;
+                }
                 var completion = new CompletionItem.from_symbol (type, method_sym, current_scope, CompletionItemKind.Method, lang_serv.get_symbol_documentation (project, method_sym));
                 completion.insertText = generate_insert_text_for_callable (type, method_sym, current_scope, method_spaces);
                 completion.insertTextFormat = InsertTextFormat.Snippet;
@@ -1050,14 +1055,17 @@ namespace Vls.CompletionEngine {
                 foreach (var constant_sym in struct_sym.get_constants ()) {
                     if (!CodeHelp.is_symbol_accessible (constant_sym, current_scope))
                         continue;
+                    // Avoid base struct constants
+                    if (current_scope.owner.name != null && current_scope.owner.name != struct_sym.scope.owner.name)
+                        continue;
                     completions.add (new CompletionItem.from_symbol (type, constant_sym, current_scope, CompletionItemKind.Constant, lang_serv.get_symbol_documentation (project, constant_sym)));
                 }
             }
 
             // get instance members of base_struct
-            if (struct_sym.base_type != null) {
+            if (struct_sym.base_struct != null) {
                 add_completions_for_type (lang_serv, project, code_style, type, struct_sym.base_struct,
-                        completions, current_scope, in_oce, false, seen_props, seen_type_symbols);
+                        completions, struct_sym.scope, in_oce, false, seen_props, seen_type_symbols);
             }
         } else if (type_symbol is Vala.TypeParameter) {
             var typeparam_sym = (Vala.TypeParameter) type_symbol;


### PR DESCRIPTION
## What does this do/fix

When inheriting from struct as an alias you can use all fo its inherited properties as is, without issues. Currently the VLs doesn't show this.

Added the required piece of code that enables looking for `struct_sym.base_struct` and add it to the list of code complete data if needed.

Some info on aliases in vala:

https://gnome.pages.gitlab.gnome.org/vala/manual/structs.html
https://docs.vala.dev/tutorials/programming-language/main/02-00-basics/02-04-data-types.html (section 2.4.7. Defining new Type from other)

This if approved, fixes #300.

## Test
The code provided on the issue should work OK with this change:

```vala
struct Foo {
    public int a;
    public int b;
    public const int FOO_CONST = 10; // Should not be shown

    public static void foo_static_method () { // Should not be shown either
        print ("Hey static foo!\n");
    }

    public void print_foo () {
        print ("Hey foo!\n");
    }
}

struct Bar : Foo {
    public int c;
    public const int BAR_CONST = 20;
    
    public static void bar_static_method () {
        print ("Hey static bar!\n");
    }

    public void print_bar () {
        print ("Hey bar !\n");
    }	
}

void main() {
    Bar my_bar;
    my_bar.
    // should show all code-complete items here
    // that is: print_bar, print_foo, a, b, c, BAR_CONST

    Bar.
    // Should show only bar_static_method and BAR_CONST
}
```

## Remarks

Not sure if this is good code though, not very versed on the whole LSP but it seems innocent enough, feel free to point to any issues about it.

Edit: added a commit that also filters const values and static/creation methods from the base, since those are technically not form the derived and cannot be used (either way vala throws and error, so they still shouldn't be shown).